### PR TITLE
toboot: fix security lockout check

### DIFF
--- a/toboot/dfu.c
+++ b/toboot/dfu.c
@@ -120,9 +120,9 @@ static uint32_t address_for_block(unsigned blockNum)
             starting_offset = (dfu_buffer[0x98 / 4] & TOBOOT_APP_PAGE_MASK) >> TOBOOT_APP_PAGE_SHIFT;
         }
         else {
-            starting_offset = 4;
+            starting_offset = 16;
         }
-        starting_offset *= 0x1000;
+        starting_offset *= 0x400;
     }
     return starting_offset + (blockNum << 10);
 }

--- a/toboot/main.c
+++ b/toboot/main.c
@@ -132,9 +132,9 @@ int test_pin_short(void)
     // If the outer pins on the edge connector are shorted, enter the bootloader.
     // We want to test CAP1A (PC1) and CAP0B (PE12).
 
-    // If the bottom four bits of 0x4094 are 70b0, don't allow
+    // If the lower 16 bits of 0x4094 are 0x70b0, don't allow
     // us to enter the bootloader this way.  This is a security lockout.
-    if (((*((uint32_t *)(((uint32_t)&__app_start__) + 0x94))) & TOBOOT_APP_MAGIC_MASK) == TOBOOT_APP_MAGIC) {
+    if (((*((uint32_t *)(((uint32_t)&__app_start__) + 0x94))) & TOBOOT_CFG_MAGIC_MASK) == TOBOOT_CFG_MAGIC) {
         return 0;
     }
 


### PR DESCRIPTION
Make security lockout check to verify magic as documented.
Implementation checked value 0x6fb0 instead of 0x70b0.

Signed-off-by: Sergei Glushchenko <gl.sergei@gmail.com>