### PR TITLE
Let make-booster compile on Mac OS X

### DIFF
--- a/booster/make-booster.c
+++ b/booster/make-booster.c
@@ -4,7 +4,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#else
 #include <endian.h>
+#endif
 
 #define BOOSTER_BIN "booster.bin"
 


### PR DESCRIPTION
The header `endian.h` is not on Mac OS X in a usable way. This change allows `make-booster.c` to compile on Mac.  Tested on hand-built tomu boards.