### PR TITLE
toboot: fix WebUSB landing page descriptor request handler

### DIFF
--- a/toboot/usb_desc.c
+++ b/toboot/usb_desc.c
@@ -29,7 +29,6 @@
  */
 
 #include "usb_desc.h"
-#include "webusb_defs.h"
 
 // USB Descriptors are binary data which the USB host reads to
 // automatically detect a USB device's capabilities.  The format
@@ -167,15 +166,7 @@ const uint8_t usb_microsoft_wcid[MSFT_WCID_LEN] = {
     0,0,0,0,0,0,                    // Reserved
 };
 
-#ifndef LANDING_PAGE_URL
-#define LANDING_PAGE_URL "dfu.tomu.im"
-#endif
-
-#define LANDING_PAGE_DESCRIPTOR_SIZE (WEBUSB_DT_URL_DESCRIPTOR_SIZE \
-                                    + sizeof(LANDING_PAGE_URL) - 1)
-#define WEBUSB_VENDOR_CODE 2
-
-static const struct webusb_url_descriptor landing_url_descriptor = {
+const struct webusb_url_descriptor landing_url_descriptor = {
     .bLength = LANDING_PAGE_DESCRIPTOR_SIZE,
     .bDescriptorType = WEBUSB_DT_URL,
     .bScheme = WEBUSB_URL_SCHEME_HTTPS,
@@ -234,6 +225,5 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
     {0x0302, 0, (const uint8_t *)&usb_string_product_name},
     {0x03EE, 0, (const uint8_t *)&usb_string_microsoft},
     {0x0F00, sizeof(full_bos), (const uint8_t *)&full_bos},
-    {0x0F01, LANDING_PAGE_DESCRIPTOR_SIZE, (const uint8_t *)&landing_url_descriptor},
     {0, 0, NULL}
 };

--- a/toboot/usb_desc.h
+++ b/toboot/usb_desc.h
@@ -34,6 +34,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "dfu.h"
+#include "webusb_defs.h"
 
 struct device_req {
     union {
@@ -78,5 +79,17 @@ typedef struct {
 } usb_descriptor_list_t;
 
 extern const usb_descriptor_list_t usb_descriptor_list[];
+
+// WebUSB Landing page URL descriptor
+#define WEBUSB_VENDOR_CODE 2
+
+#ifndef LANDING_PAGE_URL
+#define LANDING_PAGE_URL "dfu.tomu.im"
+#endif
+
+#define LANDING_PAGE_DESCRIPTOR_SIZE (WEBUSB_DT_URL_DESCRIPTOR_SIZE \
+                                    + sizeof(LANDING_PAGE_URL) - 1)
+
+extern const struct webusb_url_descriptor landing_url_descriptor;
 
 #endif

--- a/toboot/usb_dev.c
+++ b/toboot/usb_dev.c
@@ -424,6 +424,20 @@ static void usb_setup(struct usb_dev *dev)
         usb_lld_ctrl_error(dev);
         return;
 
+    case (WEBUSB_VENDOR_CODE << 8) | 0xC0: // Get WebUSB descriptor
+        if (dev->dev_req.wIndex == 0x0002)
+        {
+            if (dev->dev_req.wValue == 0x0001)
+            {
+                // Return landing page URL descriptor
+                data = (uint8_t*)&landing_url_descriptor;
+                datalen = LANDING_PAGE_DESCRIPTOR_SIZE;
+                break;
+            }
+        }
+        usb_lld_ctrl_error(dev);
+        return;
+
     case 0x0121: // DFU_DNLOAD
         if (dev->dev_req.wIndex > 0)
         {


### PR DESCRIPTION
Implement the WebUSB landing page descriptor as a vendor request per the spec instead of via the standard GET_DESCRIPTOR request.

I finally got my tomu, so I was able to test this. This fixes issue #16. The target landing page, https://dfu.tomu.im is currently a 404, though.