### PR TITLE
modify the Makefiles so that 'make clean' cleans everything that was built

### DIFF
--- a/booster/Makefile
+++ b/booster/Makefile
@@ -76,6 +76,7 @@ $(OBJ_DIR)/%.o: %.S
 $(CLEAN):
 	$(QUIET) rm -f $(wildcard $(OBJ_DIR)/*.d)
 	$(QUIET) rm -f $(wildcard $(OBJ_DIR)/*.o)
-	$(QUIET) rm -f $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol
+	$(QUIET) rm -rf $(OBJ_DIR)
+	$(QUIET) rm -f $(TARGET) $(PACKAGE).bin $(PACKAGE).ihex
 
 include $(wildcard $(OBJ_DIR)/*.d)

--- a/toboot/Makefile
+++ b/toboot/Makefile
@@ -98,9 +98,9 @@ $(OBJ_DIR)/%.o: %.S
 clean:
 	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.d))"
 	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.d))
-	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.d))"
-	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.o))
-	$(QUIET) echo "  RM      $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex"
-	-$(QUIET) $(RM) $(TARGET) $(PACKAGE).bin $(PACKAGE).symbol $(PACKAGE).ihex
+	$(QUIET) echo "  RM      $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.o)) $(OBJ_DIR)"
+	-$(QUIET) $(RM) $(subst /,$(PATH_SEP),$(wildcard $(OBJ_DIR)/*.o)) $(OBJ_DIR)
+	$(QUIET) echo "  RM      $(TARGET) $(PACKAGE).bin $(PACKAGE).dfu $(PACKAGE).ihex"
+	-$(QUIET) $(RM) $(TARGET) $(PACKAGE).bin $(PACKAGE).dfu $(PACKAGE).ihex
 
 include $(wildcard $(OBJ_DIR)/*.d)


### PR DESCRIPTION
In either the `toboot` or the `booster` directories, `make clean` leaves files behind. This patch modifies the Makefiles so that `make clean` cleans everything that was built with `make`.

Before the patch:

```
user@computer:~/git$ cp -R tomu-bootloader/ foo
user@computer:~/git$ cd foo/toboot/
user@computer:~/git/foo/toboot$ make
  CC       toboot.c	toboot.o
  CC       usb_dev.c	usb_dev.o
  CC       usb_desc.c	usb_desc.o
  CC       vectors.c	vectors.o
  CC       updater.c	updater.o
  CC       reset_handler.c	reset_handler.o
  CC       main.c	main.o
  CC       xxhash.c	xxhash.o
  CC       dfu.c	dfu.o
  LD       toboot.elf
  OBJCOPY  toboot.bin
  IHEX     toboot.ihex
  COPY  toboot.bin toboot.dfu
dfu-suffix (dfu-util) 0.9

Copyright 2011-2012 Stefan Schmidt, 2013-2014 Tormod Volden
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Suffix successfully added to file
user@computer:~/git/foo/toboot$ make clean
  RM      .obj/toboot.d .obj/usb_desc.d .obj/vectors.d .obj/updater.d .obj/usb_dev.d .obj/reset_handler.d .obj/main.d .obj/xxhash.d .obj/dfu.d
  RM      .obj/toboot.d .obj/usb_desc.d .obj/vectors.d .obj/updater.d .obj/usb_dev.d .obj/reset_handler.d .obj/main.d .obj/xxhash.d .obj/dfu.d
  RM      toboot.elf toboot.bin toboot.symbol toboot.ihex
user@computer:~/git/foo/toboot$ cd ../booster/
user@computer:~/git/foo/booster$ make
  CC       main.c	main.o
  LD       booster.elf
  OBJCOPY  booster.bin
  IHEX     booster.ihex
user@computer:~/git/foo/booster$ make clean
user@computer:~/git/foo/booster$ cd ../../
user@computer:~/git$ diff tomu-bootloader/toboot/ foo/toboot/
Only in foo/toboot/: .obj
Only in foo/toboot/: toboot.dfu
user@computer:~/git$ diff tomu-bootloader/booster foo/booster
Only in foo/booster: booster.ihex
Only in foo/booster: .obj
```

After the patch:

```
user@computer:~/git$ cp -R tomu-bootloader/ foo
user@computer:~/git$ cd foo/toboot/
user@computer:~/git/foo/toboot$ make
  CC       toboot.c	toboot.o
  CC       usb_dev.c	usb_dev.o
  CC       usb_desc.c	usb_desc.o
  CC       vectors.c	vectors.o
  CC       updater.c	updater.o
  CC       reset_handler.c	reset_handler.o
  CC       main.c	main.o
  CC       xxhash.c	xxhash.o
  CC       dfu.c	dfu.o
  LD       toboot.elf
  OBJCOPY  toboot.bin
  IHEX     toboot.ihex
  COPY  toboot.bin toboot.dfu
dfu-suffix (dfu-util) 0.9

Copyright 2011-2012 Stefan Schmidt, 2013-2014 Tormod Volden
This program is Free Software and has ABSOLUTELY NO WARRANTY
Please report bugs to http://sourceforge.net/p/dfu-util/tickets/

Suffix successfully added to file
user@computer:~/git/foo/toboot$ make clean
  RM      .obj/toboot.d .obj/usb_desc.d .obj/vectors.d .obj/updater.d .obj/usb_dev.d .obj/reset_handler.d .obj/main.d .obj/xxhash.d .obj/dfu.d
  RM      .obj/vectors.o .obj/updater.o .obj/usb_dev.o .obj/reset_handler.o .obj/main.o .obj/xxhash.o .obj/dfu.o .obj/toboot.o .obj/usb_desc.o .obj
  RM      toboot.elf toboot.bin toboot.dfu toboot.ihex
user@computer:~/git/foo/toboot$ cd ../booster/
user@computer:~/git/foo/booster$ make 
  CC       main.c	main.o
  LD       booster.elf
  OBJCOPY  booster.bin
  IHEX     booster.ihex
user@computer:~/git/foo/booster$ make clean
user@computer:~/git/foo/booster$ cd ../../
user@computer:~/git$ diff tomu-bootloader/toboot/ foo/toboot/
user@computer:~/git$ diff tomu-bootloader/booster/ foo/booster/
```

I'm not sure what `$(PACKAGE).symbol` was and since that file didn't seem to exist, I removed it from `clean` in both files.
