### PR TITLE
Clear RTC interrupts before booting.

### DIFF
--- a/toboot/main.c
+++ b/toboot/main.c
@@ -291,6 +291,7 @@ __attribute__((noreturn)) static void boot_app(void)
 
     // Reset RTC settings.
     RTC->IEN = _RTC_IEN_RESETVALUE;
+    RTC->IFC = _RTC_IFC_MASK;
     RTC->COMP0 = _RTC_COMP0_RESETVALUE;
     RTC->CTRL = _RTC_CTRL_RESETVALUE;
 


### PR DESCRIPTION
A rare timing might have left the RTC interrupt flags enabled.