### PR TITLE
Board configurability

### DIFF
--- a/toboot/Makefile
+++ b/toboot/Makefile
@@ -7,6 +7,9 @@ TRGT      ?= arm-none-eabi-
 CC         = $(TRGT)gcc
 CXX        = $(TRGT)g++
 OBJCOPY    = $(TRGT)objcopy
+# Target board. Possible values are:
+#   TOMU         The original Tomu board
+BOARD      ?= TOMU
 
 RM         = rm -rf
 COPY       = cp -a
@@ -27,6 +30,7 @@ CFLAGS     = $(ADD_CFLAGS) \
              -mcpu=cortex-m0plus -mfloat-abi=soft -mthumb \
              -ffunction-sections -fdata-sections -fno-common \
              -fomit-frame-pointer -Os \
+	     -DTOBOOT_BOARD=TOBOOT_BOARD_$(BOARD) \
              -DGIT_VERSION=u\"$(GIT_VERSION)\" -std=gnu11
 CXXFLAGS   = $(CFLAGS) -std=c++11 -fno-rtti -fno-exceptions
 LFLAGS     = $(ADD_LFLAGS) $(CFLAGS) \

--- a/toboot/board.h
+++ b/toboot/board.h
@@ -1,0 +1,28 @@
+#ifndef BOARD_H_
+#define BOARD_H_
+
+// Board-specific settings
+
+#define TOBOOT_BOARD_TOMU      0x23 // The original Tomu board
+
+#ifndef TOBOOT_BOARD
+#    define TOBOOT_BOARD TOBOOT_BOARD_TOMU
+#endif
+
+#if TOBOOT_BOARD == TOBOOT_BOARD_TOMU
+// Red LED at PB7
+#    define LED0_PORT 1
+#    define LED0_PIN 7
+// Green LED at PA0
+#    define LED1_PORT 0
+#    define LED1_PIN 0
+// Bootloader is forced by a short between CAP1A (PC1) and CAP1B (PE12)
+#    define BUTTON_DRIVE_PORT 2
+#    define BUTTON_DRIVE_PIN 1
+#    define BUTTON_SENSE_PORT 4
+#    define BUTTON_SENSE_PIN 12
+#else
+#    error "Unknown board!"
+#endif
+
+#endif // BOARD_H_

--- a/toboot/board.h
+++ b/toboot/board.h
@@ -29,6 +29,7 @@
 // USB features
 #    define ENABLE_WEBUSB
 #    define LANDING_PAGE_URL          "dfu.tomu.im"
+#    define ENABLE_WCID
 #else
 #    error "Unknown board!"
 #endif

--- a/toboot/board.h
+++ b/toboot/board.h
@@ -21,6 +21,11 @@
 #    define BUTTON_DRIVE_PIN 1
 #    define BUTTON_SENSE_PORT 4
 #    define BUTTON_SENSE_PIN 12
+// USB identifiers
+#    define VENDOR_ID                 0x1209    // pid.codes
+#    define PRODUCT_ID                0x70b1    // Assigned to Tomu project
+#    define MANUFACTURER_NAME         u"Kosagi"
+#    define PRODUCT_NAME              u"Tomu Bootloader (0) " GIT_VERSION
 #else
 #    error "Unknown board!"
 #endif

--- a/toboot/board.h
+++ b/toboot/board.h
@@ -26,6 +26,9 @@
 #    define PRODUCT_ID                0x70b1    // Assigned to Tomu project
 #    define MANUFACTURER_NAME         u"Kosagi"
 #    define PRODUCT_NAME              u"Tomu Bootloader (0) " GIT_VERSION
+// USB features
+#    define ENABLE_WEBUSB
+#    define LANDING_PAGE_URL          "dfu.tomu.im"
 #else
 #    error "Unknown board!"
 #endif

--- a/toboot/usb_desc.c
+++ b/toboot/usb_desc.c
@@ -166,6 +166,8 @@ const uint8_t usb_microsoft_wcid[MSFT_WCID_LEN] = {
     0,0,0,0,0,0,                    // Reserved
 };
 
+#ifdef ENABLE_WEBUSB
+
 const struct webusb_url_descriptor landing_url_descriptor = {
     .bLength = LANDING_PAGE_DESCRIPTOR_SIZE,
     .bDescriptorType = WEBUSB_DT_URL,
@@ -197,6 +199,8 @@ static const struct full_bos full_bos = {
     },
 };
 
+#endif // ENABLE_WEBUSB
+
 __attribute__((aligned(4)))
 static const struct usb_string_descriptor_struct usb_string_manufacturer_name = {
     2 + MANUFACTURER_NAME_LEN,
@@ -224,6 +228,8 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
     {0x0301, 0, (const uint8_t *)&usb_string_manufacturer_name},
     {0x0302, 0, (const uint8_t *)&usb_string_product_name},
     {0x03EE, 0, (const uint8_t *)&usb_string_microsoft},
+#ifdef ENABLE_WEBUSB
     {0x0F00, sizeof(full_bos), (const uint8_t *)&full_bos},
+#endif // ENABLE_WEBUSB
     {0, 0, NULL}
 };

--- a/toboot/usb_desc.c
+++ b/toboot/usb_desc.c
@@ -145,6 +145,7 @@ static const struct usb_string_descriptor_struct string0 = {
     {0x0409}
 };
 
+#ifdef ENABLE_WCID
 // Microsoft OS String Descriptor. See: https://github.com/pbatard/libwdi/wiki/WCID-Devices
 static const struct usb_string_descriptor_struct usb_string_microsoft = {
     18, 3,
@@ -165,6 +166,7 @@ const uint8_t usb_microsoft_wcid[MSFT_WCID_LEN] = {
     0,0,0,0,0,0,0,0,                // Sub-compatible ID (unused)
     0,0,0,0,0,0,                    // Reserved
 };
+#endif // ENABLE_WCID
 
 #ifdef ENABLE_WEBUSB
 
@@ -227,7 +229,9 @@ const usb_descriptor_list_t usb_descriptor_list[] = {
     {0x0300, 0, (const uint8_t *)&string0},
     {0x0301, 0, (const uint8_t *)&usb_string_manufacturer_name},
     {0x0302, 0, (const uint8_t *)&usb_string_product_name},
+#ifdef ENABLE_WCID
     {0x03EE, 0, (const uint8_t *)&usb_string_microsoft},
+#endif // ENABLE_WCID
 #ifdef ENABLE_WEBUSB
     {0x0F00, sizeof(full_bos), (const uint8_t *)&full_bos},
 #endif // ENABLE_WEBUSB

--- a/toboot/usb_desc.h
+++ b/toboot/usb_desc.h
@@ -64,10 +64,12 @@ struct usb_string_descriptor_struct {
 #define NUM_INTERFACE             1
 #define CONFIG_DESC_SIZE          (9+9+9)
 
+#ifdef ENABLE_WCID
 // Microsoft Compatible ID Feature Descriptor
 #define MSFT_VENDOR_CODE    '~'     // Arbitrary, but should be printable ASCII
 #define MSFT_WCID_LEN       40
 extern const uint8_t usb_microsoft_wcid[MSFT_WCID_LEN];
+#endif // ENABLE_WCID
 
 typedef struct {
     uint16_t  wValue;

--- a/toboot/usb_desc.h
+++ b/toboot/usb_desc.h
@@ -35,6 +35,7 @@
 #include <stddef.h>
 #include "dfu.h"
 #include "webusb_defs.h"
+#include "board.h"
 
 struct device_req {
     union {
@@ -56,12 +57,8 @@ struct usb_string_descriptor_struct {
 };
 
 #define NUM_USB_BUFFERS           8
-#define VENDOR_ID                 0x1209    // pid.codes
-#define PRODUCT_ID                0x70b1    // Assigned to Tomu project
 #define DEVICE_VER                0x0101    // Bootloader version
-#define MANUFACTURER_NAME         u"Kosagi"
 #define MANUFACTURER_NAME_LEN     sizeof(MANUFACTURER_NAME)
-#define PRODUCT_NAME              u"Tomu Bootloader (0) " GIT_VERSION
 #define PRODUCT_NAME_LEN          sizeof(PRODUCT_NAME)
 #define EP0_SIZE                  64
 #define NUM_INTERFACE             1

--- a/toboot/usb_desc.h
+++ b/toboot/usb_desc.h
@@ -77,6 +77,7 @@ typedef struct {
 
 extern const usb_descriptor_list_t usb_descriptor_list[];
 
+#ifdef ENABLE_WEBUSB
 // WebUSB Landing page URL descriptor
 #define WEBUSB_VENDOR_CODE 2
 
@@ -88,5 +89,6 @@ extern const usb_descriptor_list_t usb_descriptor_list[];
                                     + sizeof(LANDING_PAGE_URL) - 1)
 
 extern const struct webusb_url_descriptor landing_url_descriptor;
+#endif // ENABLE_WEBUSB
 
 #endif

--- a/toboot/usb_dev.c
+++ b/toboot/usb_dev.c
@@ -424,6 +424,7 @@ static void usb_setup(struct usb_dev *dev)
         usb_lld_ctrl_error(dev);
         return;
 
+#ifdef ENABLE_WEBUSB
     case (WEBUSB_VENDOR_CODE << 8) | 0xC0: // Get WebUSB descriptor
         if (dev->dev_req.wIndex == 0x0002)
         {
@@ -437,6 +438,7 @@ static void usb_setup(struct usb_dev *dev)
         }
         usb_lld_ctrl_error(dev);
         return;
+#endif // ENABLE_WEBUSB
 
     case 0x0121: // DFU_DNLOAD
         if (dev->dev_req.wIndex > 0)

--- a/toboot/usb_dev.c
+++ b/toboot/usb_dev.c
@@ -412,6 +412,7 @@ static void usb_setup(struct usb_dev *dev)
         usb_lld_ctrl_error(dev);
         return;
 
+#ifdef ENABLE_WCID
     case (MSFT_VENDOR_CODE << 8) | 0xC0: // Get Microsoft descriptor
     case (MSFT_VENDOR_CODE << 8) | 0xC1:
         if (dev->dev_req.wIndex == 0x0004)
@@ -423,6 +424,7 @@ static void usb_setup(struct usb_dev *dev)
         }
         usb_lld_ctrl_error(dev);
         return;
+#endif // ENABLE_WCID
 
 #ifdef ENABLE_WEBUSB
     case (WEBUSB_VENDOR_CODE << 8) | 0xC0: // Get WebUSB descriptor


### PR DESCRIPTION
This PR abstracts away hardware and product details from the bootloader and makes it usable with other boards besides the original Tomu.

The configurable parts include the pins for the leds and the bootloader force button, as well as USB ids and support for WCID and WebUSB.

At build time, the target board is specified with the Make variable `BOARD`. This is used to set the preprocessor variable `TOBOOT_BOARD`, which is then used in `board.h` to select appropriate values for the target board. The value of `TOBOOT_BOARD` is used as the board model in the boot token.

This PR only adds a configuration framework, but not yet any new boards, so the only supported value for the `BOARD` variable is currently `TOMU`, corresponding to the original board model 0x23.
