### PR TITLE
Make the location of bootloader reason in product name configurable

### DIFF
--- a/toboot/board.h
+++ b/toboot/board.h
@@ -26,6 +26,7 @@
 #    define PRODUCT_ID                0x70b1    // Assigned to Tomu project
 #    define MANUFACTURER_NAME         u"Kosagi"
 #    define PRODUCT_NAME              u"Tomu Bootloader (0) " GIT_VERSION
+#    define REASON_OFFSET             17        // index of reason code in product name
 // USB features
 #    define ENABLE_WEBUSB
 #    define LANDING_PAGE_URL          "dfu.tomu.im"

--- a/toboot/main.c
+++ b/toboot/main.c
@@ -355,10 +355,12 @@ __attribute__((noreturn)) void bootloader_main(void)
         boot_token.magic = 0;
         boot_token.boot_count = 0;
 
+#ifdef REASON_OFFSET
         // Update the iProduct field to reflect the bootloader reason,
         // which is described in a specialized product string.
         extern struct usb_string_descriptor_struct usb_string_product_name;
-        usb_string_product_name.wString[17] += bootloader_reason;
+        usb_string_product_name.wString[REASON_OFFSET] += bootloader_reason;
+#endif // REASON_OFFSET
 
         updater();
     }


### PR DESCRIPTION
I overlooked the bootloader reason code while making the product name configurable. This fixes that.