### PR TITLE
Do not include terminating null characters in string descriptors.

### DIFF
--- a/toboot/usb_desc.h
+++ b/toboot/usb_desc.h
@@ -58,8 +58,8 @@ struct usb_string_descriptor_struct {
 
 #define NUM_USB_BUFFERS           8
 #define DEVICE_VER                0x0101    // Bootloader version
-#define MANUFACTURER_NAME_LEN     sizeof(MANUFACTURER_NAME)
-#define PRODUCT_NAME_LEN          sizeof(PRODUCT_NAME)
+#define MANUFACTURER_NAME_LEN     (sizeof(MANUFACTURER_NAME) - 2)
+#define PRODUCT_NAME_LEN          (sizeof(PRODUCT_NAME) - 2)
 #define EP0_SIZE                  64
 #define NUM_INTERFACE             1
 #define CONFIG_DESC_SIZE          (9+9+9)


### PR DESCRIPTION
As per the USB specification (USB1.1, 9.6.5), do not include the
terminating null character of a C string literal in the length of a
string descriptor.

This only affects the length of the descriptor as sent. The now-superfluous terminating null characters are still allocated. This too could be fixed (with some ugly macros), but that would be a separate space optimization.
