### PR TITLE
use hardening flags when compiling

### DIFF
--- a/booster/Makefile
+++ b/booster/Makefile
@@ -1,6 +1,7 @@
-PACKAGE    = booster
-ADD_CFLAGS =
-ADD_LFLAGS = 
+PACKAGE      = booster
+ADD_CFLAGS   =
+ADD_CPPFLAGS =
+ADD_LFLAGS   =
 
 TRGT      ?= arm-none-eabi-
 CC         = $(TRGT)gcc
@@ -10,15 +11,18 @@ OBJCOPY    = $(TRGT)objcopy
 LDSCRIPT   = tomu.ld
 DBG_CFLAGS = -ggdb -g -DDEBUG -Wall
 DBG_LFLAGS = -ggdb -g -Wall
-CFLAGS     = $(ADD_CFLAGS) \
+CPPFLAGS   = -D_FORTIFY_SOURCE=2 $(ADD_CPPFLAGS)
+CFLAGS     = $(ADD_CFLAGS) $(CPPFLAGS) \
              -Wall -Wextra \
              -mcpu=cortex-m0plus -mfloat-abi=soft -mthumb \
              -ffunction-sections -fdata-sections -fno-common \
-             -fomit-frame-pointer -Os
+             -fomit-frame-pointer -O2 \
+             -Wformat -Werror=format-security
 CXXFLAGS   = $(CFLAGS) -std=c++11 -fno-rtti -fno-exceptions
 LFLAGS     = $(ADD_LFLAGS) $(CFLAGS) \
              -nostartfiles \
              -Wl,--gc-sections \
+             -Wl,-z,relro -Wl,-z,now \
              -Wl,--no-warn-mismatch,--script=$(LDSCRIPT),--build-id=none
 
 OBJ_DIR    = .obj

--- a/toboot/Makefile
+++ b/toboot/Makefile
@@ -1,6 +1,7 @@
-PACKAGE    = toboot
-ADD_CFLAGS =
-ADD_LFLAGS = 
+PACKAGE      = toboot
+ADD_CFLAGS   =
+ADD_CPPFLAGS =
+ADD_LFLAGS   =
 
 GIT_VERSION= $(shell git describe --tags)
 TRGT      ?= arm-none-eabi-
@@ -24,17 +25,20 @@ endif
 LDSCRIPT   = toboot-bl.ld
 DBG_CFLAGS = -ggdb -g -DDEBUG -Wall
 DBG_LFLAGS = -ggdb -g -Wall
-CFLAGS     = $(ADD_CFLAGS) \
-			 -DTOBOOT_APP_FLAGS=0x00006fb0 \
+CPPFLAGS   = -D_FORTIFY_SOURCE=2 $(ADD_CPPFLAGS)
+CFLAGS     = $(ADD_CFLAGS) $(CPPFLAGS) \
+             -DTOBOOT_APP_FLAGS=0x00006fb0 \
              -Wall -Wextra \
              -mcpu=cortex-m0plus -mfloat-abi=soft -mthumb \
              -ffunction-sections -fdata-sections -fno-common \
-             -fomit-frame-pointer -Os \
-	     -DTOBOOT_BOARD=TOBOOT_BOARD_$(BOARD) \
+             -fomit-frame-pointer -O2 \
+             -Wformat -Werror=format-security \
+             -DTOBOOT_BOARD=TOBOOT_BOARD_$(BOARD) \
              -DGIT_VERSION=u\"$(GIT_VERSION)\" -std=gnu11
 LFLAGS     = $(ADD_LFLAGS) $(CFLAGS) \
              -nostartfiles \
              -Wl,--gc-sections \
+             -Wl,-z,relro -Wl,-z,now \
              -Wl,--no-warn-mismatch,--script=$(LDSCRIPT),--build-id=none
 
 OBJ_DIR    = .obj


### PR DESCRIPTION
Those flags come from the Debian gcc hardening best practices: https://wiki.debian.org/Hardening

Sadly, we can't use any stack protector since it's not supported by the gcc arm cross compiler.

I also replaced `Os` by `O2`, as I found it made litteraly no difference and that's what Debian recommends:

```
user@computer:~/toboot$ ls -l *
O2-bins:
total 228
-rw-r--r-- 1 user user   5664 nov 15 00:19 toboot.bin
-rw-r--r-- 1 user user   6660 nov 15 00:19 toboot-booster.bin
-rw-r--r-- 1 user user   6676 nov 15 00:19 toboot-booster.dfu
-rw-r--r-- 1 user user 191496 nov 15 00:19 toboot.elf
-rw-r--r-- 1 user user  15964 nov 15 00:19 toboot.ihex

Os-bins:
total 228
-rw-r--r-- 1 user user   5664 nov 15 00:19 toboot.bin
-rw-r--r-- 1 user user   6660 nov 15 00:19 toboot-booster.bin
-rw-r--r-- 1 user user   6676 nov 15 00:19 toboot-booster.dfu
-rw-r--r-- 1 user user 191492 nov 15 00:19 toboot.elf
-rw-r--r-- 1 user user  15964 nov 15 00:19 toboot.ihex
```